### PR TITLE
Export all models in one go with some extra quirks

### DIFF
--- a/export.py
+++ b/export.py
@@ -135,7 +135,7 @@ def main(
 
     # Sample image for tracing (dimensions don't matter)
     image, _ = load_image("assets/sacre_coeur1.jpg")
-    image = torch.from_numpy(image).to(device).half()
+    image = torch.from_numpy(image).to(device)
 
     # Export all models with all precision, quick and dirty
     if export_all:

--- a/export.py
+++ b/export.py
@@ -1,7 +1,7 @@
 import argparse
 import subprocess
-import torch
 
+import torch
 from onnx import load_model, save_model
 from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
 

--- a/export.py
+++ b/export.py
@@ -87,7 +87,7 @@ def load_depth_anything(model, device, precision="float32"):
         return depth_anything
 
 
-def exportONNX(
+def export_onnx(
     depth_anything,
     image,
     output: str,

--- a/export.py
+++ b/export.py
@@ -149,7 +149,7 @@ def main(
                 depth_anything = load_depth_anything(model, device, precision)
                 depth_anything = export_onnx(depth_anything, image, output, opset)
                 if slim:
-                    slimModel(output)
+                    slim_model(output)
 
                 print(f"Exported model: {model} with precision: {precision}")
 

--- a/export.py
+++ b/export.py
@@ -162,7 +162,7 @@ def main(
         if precision == "float16":
             image = image.half()
         depth_anything = loadModel(model, device, precision)
-        depth_anything = exportONNX(depth_anything, image, output, opset)
+        depth_anything = export_onnx(depth_anything, image, output, opset)
         if slim:
             slim_model(output)
     else:

--- a/export.py
+++ b/export.py
@@ -1,6 +1,7 @@
 import argparse
-
+import subprocess
 import torch
+
 from onnx import load_model, save_model
 from onnxruntime.tools.symbolic_shape_infer import SymbolicShapeInference
 
@@ -14,7 +15,7 @@ def parse_args() -> argparse.Namespace:
         "--model",
         type=str,
         choices=["s", "b", "l"],
-        required=True,
+        required=False,
         help="Model size variant. Available options: 's', 'b', 'l'.",
     )
     parser.add_argument(
@@ -25,21 +26,38 @@ def parse_args() -> argparse.Namespace:
         help="Path to save the ONNX model.",
     )
 
+    parser.add_argument(
+        "--precision",
+        type=str,
+        default="float32",
+        required=False,
+        help="Precision for the model. Available options: 'float32', 'float16'.",
+    )
+
+    parser.add_argument(
+        "--slim",
+        action="store_true",
+        help="Whether to slim the model using ONNXSlim.",
+    )
+
+    parser.add_argument(
+        "--export-all",
+        action="store_true",
+        help="Whether to export all models. With all precisions and with slimming, if enabled.",
+    )
+
+    parser.add_argument(
+        "--opset",
+        type=int,
+        default=19,
+        required=False,
+        help="ONNX opset version.",
+    )
+
     return parser.parse_args()
 
 
-def export_onnx(model: str, output: str = None):
-    # Handle args
-    if output is None:
-        output = f"weights/depth_anything_vit{model}14.onnx"
-
-    # Device for tracing (use whichever has enough free memory)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-    # Sample image for tracing (dimensions don't matter)
-    image, _ = load_image("assets/sacre_coeur1.jpg")
-    image = torch.from_numpy(image).to(device)
-
+def loadModel(model, device, precision="float32"):
     # Load model params
     if model == "s":
         depth_anything = DPT_DINOv2(
@@ -63,13 +81,25 @@ def export_onnx(model: str, output: str = None):
     )
     depth_anything.eval()
 
+    if precision == "float16":
+        return depth_anything.half()
+    else:
+        return depth_anything
+
+
+def exportONNX(
+    depth_anything,
+    image,
+    output: str,
+    opset: int = 19,
+):
     torch.onnx.export(
         depth_anything,
         image,
         output,
         input_names=["image"],
         output_names=["depth"],
-        opset_version=17,
+        opset_version=opset,
         dynamic_axes={
             "image": {2: "height", 3: "width"},
             "depth": {2: "height", 3: "width"},
@@ -82,6 +112,63 @@ def export_onnx(model: str, output: str = None):
     )
 
 
+def slimModel(model: str):
+    output = model.replace(".onnx", "_slim.onnx")
+    try:
+        subprocess.run(f"python -m onnxslim {model} {output}", stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+    except Exception as e:
+        print(f"Failed to slim model: {e}")
+        return
+
+
+def main(
+    model: str,
+    output: str = None,
+    export_all: bool = False,
+    slim: bool = False,
+    precision: str = "float32",
+    opset: int = 19,
+):
+
+    # Device for tracing (use whichever has enough free memory)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Sample image for tracing (dimensions don't matter)
+    image, _ = load_image("assets/sacre_coeur1.jpg")
+    image = torch.from_numpy(image).to(device).half()
+
+    # Export all models with all precision, quick and dirty
+    if export_all:
+        print("Exporting all models with all precisions... This may take a while.")
+        for model in ["s", "b", "l"]:
+            for precision in ["float32", "float16"]:
+                print(f"Exporting model: {model} with precision: {precision}")
+                output = f"weights/depth_anything_vit{model}14_{precision}.onnx"
+                
+                image = image.float() if precision == "float32" else image.half()
+                depth_anything = loadModel(model, device, precision)
+                depth_anything = exportONNX(depth_anything, image, output, opset)
+                if slim:
+                    slimModel(output)
+
+                print(f"Exported model: {model} with precision: {precision}")
+
+        print("All models exported.")
+
+    elif model is not None:
+        # Handle args
+        if output is None:
+            output = f"weights/depth_anything_vit{model}14_{precision}.onnx"
+        if precision == "float16":
+            image = image.half()
+        depth_anything = loadModel(model, device, precision)
+        depth_anything = exportONNX(depth_anything, image, output, opset)
+        if slim:
+            slimModel(output)
+    else:
+        print("No model specified.")
+
+
 if __name__ == "__main__":
     args = parse_args()
-    export_onnx(**vars(args))
+    main(**vars(args))

--- a/export.py
+++ b/export.py
@@ -57,7 +57,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def loadModel(model, device, precision="float32"):
+def load_depth_anything(model, device, precision="float32"):
     # Load model params
     if model == "s":
         depth_anything = DPT_DINOv2(

--- a/export.py
+++ b/export.py
@@ -147,7 +147,7 @@ def main(
                 
                 image = image.float() if precision == "float32" else image.half()
                 depth_anything = load_depth_anything(model, device, precision)
-                depth_anything = exportONNX(depth_anything, image, output, opset)
+                depth_anything = export_onnx(depth_anything, image, output, opset)
                 if slim:
                     slimModel(output)
 

--- a/export.py
+++ b/export.py
@@ -146,7 +146,7 @@ def main(
                 output = f"weights/depth_anything_vit{model}14_{precision}.onnx"
                 
                 image = image.float() if precision == "float32" else image.half()
-                depth_anything = loadModel(model, device, precision)
+                depth_anything = load_depth_anything(model, device, precision)
                 depth_anything = exportONNX(depth_anything, image, output, opset)
                 if slim:
                     slimModel(output)

--- a/export.py
+++ b/export.py
@@ -161,7 +161,7 @@ def main(
             output = f"weights/depth_anything_vit{model}14_{precision}.onnx"
         if precision == "float16":
             image = image.half()
-        depth_anything = loadModel(model, device, precision)
+        depth_anything = load_depth_anything(model, device, precision)
         depth_anything = export_onnx(depth_anything, image, output, opset)
         if slim:
             slim_model(output)

--- a/export.py
+++ b/export.py
@@ -112,7 +112,7 @@ def export_onnx(
     )
 
 
-def slimModel(model: str):
+def slim_model(model: str):
     output = model.replace(".onnx", "_slim.onnx")
     try:
         subprocess.run(f"python -m onnxslim {model} {output}", stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)

--- a/export.py
+++ b/export.py
@@ -164,7 +164,7 @@ def main(
         depth_anything = loadModel(model, device, precision)
         depth_anything = exportONNX(depth_anything, image, output, opset)
         if slim:
-            slimModel(output)
+            slim_model(output)
     else:
         print("No model specified.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ opencv-python
 torch
 torchvision
 tqdm
+onnxslim


### PR DESCRIPTION
Hi, 

This pr should allow for some more options such as exporting all models in one go, the desired precision ( fp16 / fp32, TensorRT 10 sometimes throws a fit with the exports' precision ), desired opset if wanted ( 19 is the max with torch 2.2 but the nightly builds allow for opset 20 as well ) and also allow for model optimizations through [ONNXSlim](https://github.com/tsingmicro-toolchain/OnnxSlim).

