### PR TITLE
Metric models activation function fix

### DIFF
--- a/depth_anything_v2/dpt.py
+++ b/depth_anything_v2/dpt.py
@@ -45,6 +45,7 @@ class DPTHead(nn.Module):
         use_bn=False,
         out_channels=[256, 512, 1024, 1024],
         use_clstoken=False,
+        metric=False
     ):
         super(DPTHead, self).__init__()
 
@@ -117,19 +118,34 @@ class DPTHead(nn.Module):
         self.scratch.output_conv1 = nn.Conv2d(
             head_features_1, head_features_1 // 2, kernel_size=3, stride=1, padding=1
         )
-        self.scratch.output_conv2 = nn.Sequential(
-            nn.Conv2d(
-                head_features_1 // 2,
-                head_features_2,
-                kernel_size=3,
-                stride=1,
-                padding=1,
-            ),
-            nn.ReLU(True),
-            nn.Conv2d(head_features_2, 1, kernel_size=1, stride=1, padding=0),
-            nn.ReLU(True),
-            nn.Identity(),
-        )
+
+        if not metric:
+            self.scratch.output_conv2 = nn.Sequential(
+                nn.Conv2d(
+                    head_features_1 // 2,
+                    head_features_2,
+                    kernel_size=3,
+                    stride=1,
+                    padding=1,
+                ),
+                nn.ReLU(True),
+                nn.Conv2d(head_features_2, 1, kernel_size=1, stride=1, padding=0),
+                nn.ReLU(True),
+                nn.Identity(),
+            )
+        else:
+            self.scratch.output_conv2 = nn.Sequential(
+                nn.Conv2d(
+                    head_features_1 // 2,
+                    head_features_2,
+                    kernel_size=3,
+                    stride=1,
+                    padding=1,
+                ),
+                nn.ReLU(True),
+                nn.Conv2d(head_features_2, 1, kernel_size=1, stride=1, padding=0),
+                nn.Sigmoid()
+            )
 
     def forward(self, out_features, patch_h, patch_w):
         out = []
@@ -198,6 +214,7 @@ class DepthAnythingV2(nn.Module):
             use_bn,
             out_channels=out_channels,
             use_clstoken=use_clstoken,
+            metric=(max_depth is not None),
         )
         self.max_depth = max_depth
 


### PR DESCRIPTION
Hi, thanks for the tool and exported models. This PR is aimed at fixing issues with metric exported models.

I've been having some issues with metric models, mainly having indoor variant output 0s. I've seen similar issues raised in https://github.com/fabio-sim/Depth-Anything-ONNX/issues/16#issuecomment-2293057457 .

What I've found is that the last two activation function between relative and metric models in original repo are different. While I see that you've taken into account the last activation difference (https://github.com/fabio-sim/Depth-Anything-ONNX/commit/3128cb99056785cc843ad6deda2f53f2e2ff4272#diff-f5333b49dc69ab891064d6eb216dbf39f933d3a7f94b2ef18e4ea18aadebca26R215), changing it from ReLU to product with `max_depth`, there is still one in `DPTHead` that needs to be implemented. It changes the last activation from ReLU to Sigmoid. This discrepancy confirms with all 0 output as ReLU would clip it.
Changing this, metric models behave as torch native ones.

Note: With this fix, exported metric models have to be re-released.